### PR TITLE
Add bcrypt to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ PyYAML>=5.1.2
 yamlcfg
 appdirs
 whoosh
+bcrypt
 bidict
 unidecode
 colormath


### PR DESCRIPTION
I got this:

```py
…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/OpenSSL/crypto.py:14: CryptographyDeprecationWarning: Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.
  from cryptography import utils, x509
Unhandled Error
Traceback (most recent call last):
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/application/twist/_options.py", line 177, in parseOptions
    Options.parseOptions(self, options=options)
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/python/usage.py", line 265, in parseOptions
    for (cmd, short, parser, doc) in self.subCommands:
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/application/twist/_options.py", line 196, in subCommands
    plugins = self.plugins
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/application/twist/_options.py", line 186, in plugins
    for plugin in getPlugins(IServiceMaker):
--- <exception caught here> ---
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/plugin.py", line 206, in getPlugins
    adapted = interface(plugin, None)
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/zope/interface/interface.py", line 935, in _call_conform
    return conform(self)
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/plugin.py", line 58, in __conform__
    return self.load()
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/plugin.py", line 53, in load
    return namedAny(self.dropin.moduleName + "." + self.name)
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/python/reflect.py", line 298, in namedAny
    topLevelPackage = _importAndCheckStack(trialname)
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/python/reflect.py", line 245, in _importAndCheckStack
    raise excValue.with_traceback(excTraceback)
  File "…/PyTIBot/twisted/plugins/pytibot_plugin.py", line 30, in <module>
    from twisted.conch import manhole_tap
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/conch/manhole_tap.py", line 17, in <module>
    from twisted.conch import manhole, manhole_ssh, telnet
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/conch/manhole_ssh.py", line 15, in <module>
    from twisted.conch.ssh import factory, session
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/conch/ssh/factory.py", line 17, in <module>
    from twisted.conch.ssh import _kex, transport, userauth, connection
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/conch/ssh/transport.py", line 36, in <module>
    from twisted.conch.ssh import address, keys, _kex
  File "…/.pyenv/versions/3.5.10/lib/python3.5/site-packages/twisted/conch/ssh/keys.py", line 18, in <module>
    import bcrypt
builtins.ImportError: No module named 'bcrypt'
```

Note: I'm running python 3.5 because I know it works on it. There may be newer versions that also work, but I know latest one does not.